### PR TITLE
CEBU: Evidence calculation asks for the last weights, namely logWlast!

### DIFF
--- a/Bayesian Inference Tools/5. CEBU/CEBU_Python/CEBU_GM.py
+++ b/Bayesian Inference Tools/5. CEBU/CEBU_Python/CEBU_GM.py
@@ -204,7 +204,7 @@ def CEBU_GM(N:int, log_likelihood, distr:ERANataf, max_it:int, CV_target:float,
     # Compute nESS
     nESS = np.exp(2*logsumexp(logWlast)-logsumexp(2*logWlast)-np.log(N_last))
 
-    evidence = np.exp(logsumexp(logW)-np.log(N_last)).squeeze() # Evidence
+    evidence = np.exp(logsumexp(logWlast)-np.log(N_last)).squeeze() # Evidence
 
     xlast:np.ndarray = u2x(ulast)
 

--- a/Bayesian Inference Tools/5. CEBU/CEBU_Python/CEBU_vMFNM.py
+++ b/Bayesian Inference Tools/5. CEBU/CEBU_Python/CEBU_vMFNM.py
@@ -215,7 +215,7 @@ def CEBU_vMFNM(N:int, log_likelihood, distr:ERANataf, max_it:int, CV_target:floa
     # Compute nESS
     nESS = np.exp(2*logsumexp(logWlast)-logsumexp(2*logWlast)-np.log(N_last))
 
-    evidence = np.exp(logsumexp(logW)-np.log(N_last)).squeeze() # Evidence
+    evidence = np.exp(logsumexp(logWlast)-np.log(N_last)).squeeze() # Evidence
 
     k_fin = len(v_tot[-1]["mu_hat"])
 


### PR DESCRIPTION
Dear ERA-Team,

to my understanding and within the original version of the code, the calculation of the evidence asks for the use of logWlast instead of logW. That is of particular importance if N (per step) and N_last are different from each other!
Further, I wonder why the nESS is not returned? It is one of the easiest to interpret metrics for the performance of the algorithm.
Many thanks in advance!

Best
Michael