### PR TITLE
ERADist and ERANataf: Empirical Distribution Object and Jacobian for All Data Points!

### DIFF
--- a/Bayesian Inference Tools/5. CEBU/CEBU_Python/CEBU_GM.py
+++ b/Bayesian Inference Tools/5. CEBU/CEBU_Python/CEBU_GM.py
@@ -204,7 +204,7 @@ def CEBU_GM(N:int, log_likelihood, distr:ERANataf, max_it:int, CV_target:float,
     # Compute nESS
     nESS = np.exp(2*logsumexp(logWlast)-logsumexp(2*logWlast)-np.log(N_last))
 
-    evidence = np.exp(logsumexp(logW)-np.log(N_last)).squeeze() # Evidence
+    evidence = np.exp(logsumexp(logWlast)-np.log(N_last)).squeeze() # Evidence
 
     xlast:np.ndarray = u2x(ulast)
 

--- a/Bayesian Inference Tools/5. CEBU/CEBU_Python/CEBU_vMFNM.py
+++ b/Bayesian Inference Tools/5. CEBU/CEBU_Python/CEBU_vMFNM.py
@@ -215,7 +215,7 @@ def CEBU_vMFNM(N:int, log_likelihood, distr:ERANataf, max_it:int, CV_target:floa
     # Compute nESS
     nESS = np.exp(2*logsumexp(logWlast)-logsumexp(2*logWlast)-np.log(N_last))
 
-    evidence = np.exp(logsumexp(logW)-np.log(N_last)).squeeze() # Evidence
+    evidence = np.exp(logsumexp(logWlast)-np.log(N_last)).squeeze() # Evidence
 
     k_fin = len(v_tot[-1]["mu_hat"])
 

--- a/Bayesian Inference Tools/5. CEBU/CEBU_Python/ERANataf.py
+++ b/Bayesian Inference Tools/5. CEBU/CEBU_Python/ERANataf.py
@@ -245,8 +245,8 @@ class ERANataf(object):
         standard normal space U.
         X must be a [n,d]-shaped array (n = number of data points,
         d = dimensions).
-        The Jacobian of the transformation of the first given data
-        point is only given as an output in case that the input
+        The Jacobian of the transformation of all given data
+        points is only given as an output in case that the input
         argument Jacobian=True .
         """
         
@@ -275,10 +275,13 @@ class ERANataf(object):
         U = np.linalg.solve(self.A, Z.squeeze()).T
                 
         if Jacobian:
+            N_samples, _ = X.shape
+            Jac = np.zeros([N_samples, n_dim, n_dim])
             diag = np.zeros([n_dim, n_dim])
-            for i in range(n_dim):
-                diag[i, i] = self.Marginals[i].pdf(X[0,i])/stats.norm.pdf(Z[i,0])
-            Jac = np.linalg.solve(self.A, diag)
+            for n in range(N_samples):    
+                for i in range(n_dim):
+                    diag[i, i] = self.Marginals[i].pdf(X[n,i])/stats.norm.pdf(Z[i,n])
+                Jac[n, ...] = np.linalg.solve(self.A, diag)
             return np.squeeze(U), Jac
         else:
             return np.squeeze(U)
@@ -291,8 +294,8 @@ class ERANataf(object):
         to physical space X.
         U must be a [n,d]-shaped array (n = number of data points,
         d = dimensions).
-        The Jacobian of the transformation of the first given data
-        point is only given as an output in case that the input
+        The Jacobian of the transformation for all given data
+        points is only given as an output in case that the input
         argument Jacobian=True .
         """
         
@@ -317,10 +320,13 @@ class ERANataf(object):
             X[:, i] = self.Marginals[i].icdf(stats.norm.cdf(Z[i, :]))
 
         if Jacobian:
+            N_samples, _ = X.shape
+            Jac = np.zeros([N_samples, n_dim, n_dim])
             diag = np.zeros([n_dim, n_dim])
-            for i in range(n_dim):
-                diag[i, i] = stats.norm.pdf(Z[i,0])/self.Marginals[i].pdf(X[0,i])
-            Jac = np.dot(diag, self.A)
+            for n in range(N_samples):
+                for i in range(n_dim):
+                    diag[i, i] = stats.norm.pdf(Z[i,0])/self.Marginals[i].pdf(X[0,i])
+                Jac[n, ...] = np.dot(diag, self.A)
             return np.squeeze(X), Jac
         else:
             return np.squeeze(X)

--- a/ERADist/ERA_Distribution_Classes_Python/Classes/ERADist.py
+++ b/ERADist/ERA_Distribution_Classes_Python/Classes/ERADist.py
@@ -4,6 +4,8 @@ import scipy as sp
 from scipy import optimize, stats, special
 import warnings
 
+from EmpiricalDist import DistME
+
 """
 ---------------------------------------------------------------------------
 Generation of distribution objects
@@ -135,6 +137,7 @@ class ERADist(object):
       Truncated normal:           Obj = ERADist('truncatednormal','DATA',[[X],[a,b]])
       Uniform:                    Obj = ERADist('uniform','DATA',[X])
       Weibull:                    Obj = ERADist('weibull','DATA',[X])
+      Empirical:                  Obj = ERADist('empirical', 'DATA', [X, [weights, cdfMethod, pdfMethod, kdeKwargsDict]])
           
     """
 #%%
@@ -856,7 +859,16 @@ class ERADist(object):
                 pars = stats.weibull_min.fit(val, floc=0)
                 self.Par = {'a_n':pars[2], 'k':pars[0]}
                 self.Dist = stats.weibull_min(c=self.Par['k'], scale=self.Par['a_n'])
-
+                
+            elif name.lower() == "empirical":
+                X = val[0]
+                self.Par = {
+                    'weights': val[1],
+                    'cdfMethod': val[2],
+                    'pdfMethod': val[3],
+                }
+                self.Par.update(val[4])
+                self.Dist = DistME(data=X, **self.Par) # implemented by Michael Engel
             
             else:
                 raise RuntimeError("Distribution type '" + name + "' not available.")

--- a/ERADist/ERA_Distribution_Classes_Python/Classes/EmpiricalDist.py
+++ b/ERADist/ERA_Distribution_Classes_Python/Classes/EmpiricalDist.py
@@ -1,0 +1,178 @@
+#### Michael Engel ### 2025-07-16 ### EmpiricalDist.py ###
+import warnings
+import numpy as np
+import scipy.stats as sps
+from scipy.interpolate import interp1d, PchipInterpolator
+
+class DistME():
+    """
+    Returns a distribution object similar to scipy.stats based on a dataset
+    given by the user.
+    """
+    #%% initialization
+    def __init__(
+        self,
+        data,
+        weights = None, # None for equal weights
+        cdfMethod = "pchip", # pchip, linear, slinear...
+        pdfMethod = "kde", # kde, linear, slinear, quadratic, cubic...
+        **pdfMethodParams
+    ):
+        '''
+        :param data: One dimensional data array.
+        :param weights: Weights associated to the data array. The default is None.
+        :param cdfMethod: Desired method for the CDF creation. The default is PCHIP.
+        :param pdfMethod: Desired method for the PDF creation. The default is KDE.
+        :params pdfMethodParams: Optional scipy.stats.gaussian_kde keyword arguments for the case of KDE based PDF creation.
+        '''
+        
+        self.cleanData = data[~np.isnan(data)]
+        self._N = len(self.cleanData)
+        self.normalizedWeights = np.ones_like(self.cleanData)/self._N if weights is None else weights[~np.isnan(data)]/np.sum(weights[~np.isnan(data)])
+        
+        self.cdfMethod = cdfMethod
+        self.pdfMethod = pdfMethod
+        self.pdfMethodParams = pdfMethodParams
+        
+        # statistics
+        self._mean = np.sum(self.cleanData*self.normalizedWeights)
+        self._var = np.cov(self.cleanData, aweights=self.normalizedWeights)
+        self._std = np.sqrt(self._var)
+        
+        # cdf and inverse cdf
+        if self.cdfMethod.lower()=="pchip":
+            print("DistME: Using PCHIP for CDF!")
+            self._cdf = create_weighted_cdf_PCHIP(self.cleanData, self.normalizedWeights)
+            self._ppf = create_weighted_ppf_PCHIP(self.cleanData, self.normalizedWeights)
+            
+        elif self.cdfMethod.lower()=="linear" or self.cdfMethod.lower()=="slinear":
+            print(f"DistME: Using {self.cdfMethod.lower()} interpolation for CDF!")
+            self._cdf = create_weighted_cdf_interp1d(self.cleanData, self.normalizedWeights, kind=self.cdfMethod.lower())
+            self._ppf = create_weighted_ppf_interp1d(self.cleanData, self.normalizedWeights, kind=self.cdfMethod.lower())
+        else:
+            warnings.warn(f"DistME: Using {self.cdfMethod.lower()} interpolation for CDF! Please note that we do recommend either PCHIP or somewhat linear interpolation!")
+            self._cdf = create_weighted_cdf_interp1d(self.cleanData, self.normalizedWeights, kind=self.cdfMethod.lower())
+            self._ppf = create_weighted_ppf_interp1d(self.cleanData, self.normalizedWeights, kind=self.cdfMethod.lower())
+            
+        # pdf
+        if isinstance(self.pdfMethod, str) and self.pdfMethod.lower()=="kde":
+            print("DistME: Using Gaussian KDE for PDF!")
+            dataSorted, weightsSorted = sortDataWeights(self.cleanData, self.normalizedWeights)
+            self._pdf = sps.gaussian_kde(dataset=dataSorted, weights=weightsSorted, **pdfMethodParams)
+            
+        elif isinstance(self.pdfMethod, str) and self.pdfMethod.lower()=="pchip":
+            if not (self.cdfMethod.lower()=="pchip"):
+                raise RuntimeError("DistME: cdfMethod has to be PCHIP as well in order to use its derivative for the PDF!")
+            else:
+                print("DistME: Using PCHIP derivative for PDF!")
+                self._pdf = self._cdf.derivative(1)
+                
+        else:
+            print("DistME: Using numerical derivative for PDF!")
+            self._pdf = create_normalized_pdf_from_cdf(self._cdf, self.cleanData.min(), self.cleanData.max(),
+                num_points = self.pdfMethod if isinstance(self.pdfMethod, int) else int(1+3.3*np.log10(self._N)) if self.pdfMethod.lower()=="log" else np.max([1,int(np.sqrt(self._N))]),
+                kind = "linear" if self.pdfMethod.lower()=="log" or isinstance(self.pdfMethod, int) else self.pdfMethod.lower()
+            )
+        pass
+    
+    def N(self):
+        return self._N
+                
+    def mean(self):
+        return self._mean
+    
+    def var(self):
+        return self._var
+    
+    def std(self):
+        return self._std
+
+    def pdf(self, x):
+        return self._pdf(x)
+                
+    def cdf(self, x):
+        return self._cdf(x)
+    
+    def ppf(self, y): # inverse cdf
+        return self._ppf(y)
+       
+    def rvs(self, size=None): # random samples
+        rands = np.random.rand(size)
+        return self.ppf(rands)
+    
+def sortDataWeights(data, weights):
+    data = np.asarray(data)
+    weights = np.asarray(weights)
+    
+    sort_idx = np.argsort(data)
+    sorted_data = data[sort_idx]
+    sorted_weights = weights[sort_idx]
+    
+    return sorted_data, sorted_weights
+
+### CDF utils
+# interpolation based cdf
+def create_weighted_cdf_interp1d(data, weights, kind="linear"):
+    sorted_data, sorted_weights = sortDataWeights(data, weights)
+    
+    cum_weights = np.cumsum(sorted_weights)-sorted_weights[0]
+    total_weight = cum_weights[-1]
+    weighted_cdf_values = cum_weights / total_weight
+
+    cdf_func = interp1d(sorted_data, weighted_cdf_values,
+                        kind=kind,
+                        bounds_error=False,
+                        fill_value=(0.0, 1.0),
+                        assume_sorted=True)
+    return cdf_func
+
+def create_weighted_ppf_interp1d(data, weights, kind="linear"):
+    sorted_data, sorted_weights = sortDataWeights(data, weights)
+
+    cum_weights = np.cumsum(sorted_weights)-sorted_weights[0]
+    total_weight = cum_weights[-1]
+    weighted_cdf_values = cum_weights / total_weight
+
+    cdf_func = interp1d(weighted_cdf_values, sorted_data, 
+                        kind=kind,
+                        bounds_error=False,
+                        fill_value=(sorted_data.min(), sorted_data.max()),
+                        assume_sorted=True)
+    return cdf_func
+
+# pchip based cdf
+def create_weighted_cdf_PCHIP(data, weights):
+    sorted_data, sorted_weights = sortDataWeights(data, weights)
+
+    cum_weights = np.cumsum(sorted_weights)-sorted_weights[0]
+    total_weight = cum_weights[-1]
+    weighted_cdf_values = cum_weights / total_weight
+    
+    cdf_func = PchipInterpolator(sorted_data, weighted_cdf_values, extrapolate=False)
+    return cdf_func
+
+def create_weighted_ppf_PCHIP(data, weights):
+    sorted_data, sorted_weights = sortDataWeights(data, weights)
+
+    cum_weights = np.cumsum(sorted_weights)-sorted_weights[0]
+    total_weight = cum_weights[-1]
+    weighted_cdf_values = cum_weights / total_weight
+    
+    cdf_func = PchipInterpolator(weighted_cdf_values, sorted_data, extrapolate=False)
+    return cdf_func
+
+### PDF utils
+def create_normalized_pdf_from_cdf(cdf_func, x_min, x_max, num_points=1000, kind="linear"):
+    x_grid = np.linspace(x_min, x_max, num_points)
+    cdf_vals = cdf_func(x_grid)
+    
+    raw_pdf_vals = np.gradient(cdf_vals, x_grid)
+    area = np.trapz(raw_pdf_vals, x_grid)
+    
+    if area != 0:
+        pdf_vals = raw_pdf_vals / area
+    else:
+        pdf_vals = raw_pdf_vals
+    
+    pdf_func = interp1d(x_grid, pdf_vals, kind=kind, bounds_error=False, fill_value=0.0)
+    return pdf_func

--- a/ERADist/ERA_Distribution_Classes_Python/Examples/Example_DistME.py
+++ b/ERADist/ERA_Distribution_Classes_Python/Examples/Example_DistME.py
@@ -1,0 +1,78 @@
+### Michael Engel ### 2025-07-16 ### Example_DistME.py ###
+import numpy as np
+import matplotlib.pyplot as plt
+
+from EmpiricalDist import DistME
+
+def sample_bimodal_gaussian(n_samples=1000, mix_weights=(0.4, 0.6),
+                            means=(-2, 3), stds=(0.7, 1.2), random_seed=42):
+    np.random.seed(random_seed)
+    # choose component for each sample
+    comps = np.random.choice([0, 1], size=n_samples, p=mix_weights)
+    data = np.where(
+        comps == 0,
+        np.random.normal(loc=means[0], scale=stds[0], size=n_samples),
+        np.random.normal(loc=means[1], scale=stds[1], size=n_samples),
+    )
+    return data
+
+if __name__ == "__main__":
+    # 1. Generate a bimodal Gaussian mixture dataset
+    N = 2000
+    data = sample_bimodal_gaussian(n_samples=N,
+                                   mix_weights=(0.2, 0.8),
+                                   means=(-2, 3),
+                                   stds=(0.5, 1.0))
+    weights = np.ones_like(data)  # uniform empirical weights
+
+    # 2. Fit the empirical distribution
+    dist_emp = DistME(data, weights=weights, cdfMethod="pchip", pdfMethod="kde", bw_method=0.1)
+
+    # 3. Plot histogram + estimated PDF
+    x_grid = np.linspace(data.min() - 1, data.max() + 1, 1000)
+    pdf_vals = dist_emp.pdf(x_grid)
+
+    plt.figure(figsize=(8, 4))
+    plt.hist(data, bins=40, density=True, alpha=0.5, color="gray", label="Original data")
+    plt.plot(x_grid, pdf_vals, 'r-', linewidth=2, label="Estimated PDF")
+    plt.title("Original Histogram with Estimated PDF Overlay")
+    plt.xlabel("x")
+    plt.ylabel("Density")
+    plt.legend(loc="best")
+    plt.tight_layout()
+    plt.show()
+
+    # 4. Plot CDF and inverse CDF (PPF)
+    cdf_vals = dist_emp.cdf(x_grid)
+    y_grid = np.linspace(0, 1, 1000)
+    ppf_vals = dist_emp.ppf(y_grid)
+
+    fig, axes = plt.subplots(1, 2, figsize=(12, 4))
+
+    axes[0].plot(x_grid, cdf_vals, 'b-')
+    axes[0].set_title("Estimated CDF")
+    axes[0].set_xlabel("x")
+    axes[0].set_ylabel("F(x)")
+
+    axes[1].plot(y_grid, ppf_vals, 'g-')
+    axes[1].set_title("Estimated Inverse CDF (PPF)")
+    axes[1].set_xlabel("Quantile")
+    axes[1].set_ylabel("x")
+
+    plt.tight_layout()
+    plt.show()
+
+    # 5. Draw new samples from the empirical distribution
+    M = 2000
+    sampled = dist_emp.rvs(size=M)
+
+    # 6. Compare histograms: original vs resampled
+    plt.figure(figsize=(8, 4))
+    plt.hist(data, bins=40, density=True, alpha=0.4, label="Original data")
+    plt.hist(sampled, bins=40, density=True, alpha=0.4, label="DistME samples")
+    plt.title("Comparison of Original and DistME Histograms")
+    plt.xlabel("x")
+    plt.ylabel("Density")
+    plt.legend(loc="best")
+    plt.tight_layout()
+    plt.show()

--- a/ERADist/ERA_Distribution_Classes_Python/Examples/Example_ERADist_empirical.py
+++ b/ERADist/ERA_Distribution_Classes_Python/Examples/Example_ERADist_empirical.py
@@ -1,0 +1,110 @@
+from ERADist import ERADist
+import numpy as np
+import matplotlib.pylab as plt
+
+'''
+---------------------------------------------------------------------------
+Example file: Definition and use of ERADist empirical distribution object
+---------------------------------------------------------------------------
+ 
+ In this example an empirical distribution is defined by a set of datapoints.
+ Furthermore the different methods of ERADist are illustrated. For other
+ distributions and more information on ERADist please have a look at the
+ provided documentation or execute the command 'help(ERADist)'.
+ 
+---------------------------------------------------------------------------
+Additions regarding empirical distributions:
+Michael Engel
+
+Developed by:
+Sebastian Geyer
+Felipe Uribe
+Iason Papaioannou
+Daniel Straub
+
+Assistant Developers:
+Luca Sardi
+Alexander von Ramm
+Matthias Willer
+Peter Kaplan
+
+Engineering Risk Analysis Group
+Technische Universitat Munchen
+www.bgu.tum.de/era
+Contact: Antonios Kamariotis (antonis.kamariotis@tum.de)
+---------------------------------------------------------------------------
+Version 2025-07
+---------------------------------------------------------------------------
+References:
+1. Documentation of the ERA Distribution Classes
+---------------------------------------------------------------------------
+'''
+
+def sample_bimodal_gaussian(n_samples=1000, mix_weights=(0.4, 0.6),
+                            means=(-2, 3), stds=(0.7, 1.2), random_seed=42):
+    np.random.seed(random_seed)
+    # choose component for each sample
+    comps = np.random.choice([0, 1], size=n_samples, p=mix_weights)
+    data = np.where(
+        comps == 0,
+        np.random.normal(loc=means[0], scale=stds[0], size=n_samples),
+        np.random.normal(loc=means[1], scale=stds[1], size=n_samples),
+    )
+    return data
+
+if __name__ == "__main__":
+    np.random.seed(2025) #initializing random number generator
+    n = 2000 #number of data points
+    
+    # generate a bimodal Gaussian mixture dataset
+    data = sample_bimodal_gaussian(n_samples=n,
+                                   mix_weights=(0.2, 0.8),
+                                   means=(-2, 3),
+                                   stds=(0.5, 1.0))
+    weights = None
+    
+    ''' Definition of an ERADist object by a dataset '''
+    dist = ERADist('empirical','DATA',[data, weights, "pchip", "kde", {"bw_method":None}])
+    
+    # computation of the first two moments
+    mean_dist = dist.mean()
+    std_dist = dist.std()
+    
+    # generation of n random samples
+    n = 2000;
+    samples = dist.random(n);
+    
+    ''' Other methods '''
+    # generation of n samples x to work with
+    x = dist.random(n)
+    
+    # computation of the PDF for the samples x
+    pdf = dist.pdf(x)
+    
+    # computation of the CDF for the samples x
+    cdf = dist.cdf(x)
+    
+    # computation of the inverse CDF based on the CDF values (-> initial x)
+    icdf = dist.icdf(cdf)
+    
+    
+    ''' Plot of the PDF and CDF '''
+    x_plot = np.linspace(data.min()-1,data.max()+1,200);     # values for which the PDF and CDF are evaluated 
+    pdf = dist.pdf(x_plot);     # computation of PDF
+    cdf = dist.cdf(x_plot);     # computation of CDF
+    
+    fig_dist = plt.figure(figsize=[10, 10])
+    
+    fig_pdf = fig_dist.add_subplot(211)
+    fig_pdf.hist(data, density=True, bins=int(np.sqrt(len(data))), label="data", color='r', alpha=0.3)
+    fig_pdf.plot(x_plot, pdf, 'b', lw=2, label="Empirical PDF")
+    fig_pdf.set_xlim([data.min(), data.max()])
+    fig_pdf.set_xlabel(r'$X$')
+    fig_pdf.set_ylabel(r'$PDF$')
+    fig_pdf.legend()
+    
+    fig_cdf = fig_dist.add_subplot(212)
+    fig_cdf.plot(x_plot, cdf, "b", lw=2, label="Empirical CDF")
+    fig_cdf.set_xlim([data.min(), data.max()])
+    fig_cdf.set_xlabel(r'$X$')
+    fig_cdf.set_ylabel(r'$CDF$')

--- a/ERADist/ERA_Distribution_Classes_Python/Examples/Example_ERANataf_empirical.py
+++ b/ERADist/ERA_Distribution_Classes_Python/Examples/Example_ERANataf_empirical.py
@@ -1,0 +1,126 @@
+from ERADist import ERADist
+from ERANataf import ERANataf
+import numpy as np
+import matplotlib.pylab as plt
+from mpl_toolkits.mplot3d import Axes3D
+
+'''
+---------------------------------------------------------------------------
+Example file: Definition and use of ERADist empirical 
+---------------------------------------------------------------------------
+
+ In this script the definition of a joint distribution object including an
+ empirical distribution based on a dataset with the ERANataf class and the
+ use of its methods are shown. For more information on ERANataf please have
+ a look at the provided documentation. 
+---------------------------------------------------------------------------
+Additions regarding empirical distributions and Jacobians:
+Michael Engel
+
+Developed by:
+Sebastian Geyer
+Felipe Uribe
+Iason Papaioannou
+Daniel Straub
+
+Assistant Developers:
+Luca Sardi
+Alexander von Ramm
+Matthias Willer
+Peter Kaplan
+
+Engineering Risk Analysis Group
+Technische Universitat Munchen
+www.bgu.tum.de/era
+Contact: Antonios Kamariotis (antonis.kamariotis@tum.de)
+---------------------------------------------------------------------------
+Version 2025-07
+---------------------------------------------------------------------------
+References:
+1. Documentation of the ERA Distribution Classes
+---------------------------------------------------------------------------
+'''
+
+def sample_bimodal_gaussian(n_samples=1000, mix_weights=(0.4, 0.6),
+                            means=(-2, 3), stds=(0.7, 1.2), random_seed=42):
+    np.random.seed(random_seed)
+    # choose component for each sample
+    comps = np.random.choice([0, 1], size=n_samples, p=mix_weights)
+    data = np.where(
+        comps == 0,
+        np.random.normal(loc=means[0], scale=stds[0], size=n_samples),
+        np.random.normal(loc=means[1], scale=stds[1], size=n_samples),
+    )
+    return data
+
+if __name__ == "__main__":
+    np.random.seed(2025) #initializing random number generator
+    n = 2000 #number of data points
+    n_samples = 1000 # number of samples for the plot
+    
+    # generate a bimodal Gaussian mixture dataset
+    data = sample_bimodal_gaussian(n_samples=n,
+                                   mix_weights=(0.2, 0.8),
+                                   means=(-2, 3),
+                                   stds=(0.5, 1.0))
+
+    ''' Definition of the ERANataf object '''
+    
+    # definition of the marginal distributions
+    M = list()
+    M.append(ERADist('normal','PAR',[4,2]))
+    M.append(ERADist('gumbel','MOM',[1,2]))
+    M.append(ERADist('empirical','DATA',[data, None, "pchip", "linear", {}]))
+    
+    # definition of the correlation matrix
+    Rho  = np.array([[1.0, 0.5, 0.5],[0.5, 1.0, 0.5],[0.5, 0.5, 1.0]])
+    
+    # definition of the joint distribution    
+    T_Nataf = ERANataf(M,Rho)
+    
+    ''' Methods '''
+    
+    # generation of n random samples to work with
+    X = T_Nataf.random(5)
+    
+    # computation of joint PDF
+    PDF_X = T_Nataf.pdf(X)
+    
+    # computation of joint CDF
+    CDF_X = T_Nataf.cdf(X)
+    
+    # transformation from physical space X to the standard normal space U and
+    # Jacobian of the transformation of the first sample
+    U, Jac_X2U = T_Nataf.X2U(X,'Jac')
+    
+    # transformation from standard normal space U to physical space X and
+    # Jacobian of the transformation of the first sample
+    X_backtransform, Jac_U2X = T_Nataf.U2X(U,'Jac')
+    
+    
+    ''' Creation of samples in physical space, transformation to standard normal
+     space and plot of the samples to show the isoprobabilistic transformation '''
+    
+    # generation of n random samples
+    X_plot = T_Nataf.random(n_samples)
+    # transformation from physical space X to the standard normal space U 
+    U_plot = T_Nataf.X2U(X_plot)
+    
+    # plot samples in physical and standard normal space
+    fig_Samples = plt.figure(figsize=[16, 9])
+    
+    fig_SamplesAx1 = fig_Samples.add_subplot(121, projection='3d')
+    fig_SamplesAx1.scatter(X_plot[:,0], X_plot[:,1], X_plot[:,2])
+    fig_SamplesAx1.set_title('Physical Space')
+    fig_SamplesAx1.set_xlabel(r'$X_{1}$')
+    fig_SamplesAx1.set_ylabel(r'$X_{2}$')
+    fig_SamplesAx1.set_zlabel(r'$X_{3}$')
+    
+    fig_SamplesAx2 = fig_Samples.add_subplot(122, projection='3d')
+    fig_SamplesAx2.scatter(U_plot[:,0], U_plot[:,1], U_plot[:,2],color='r')
+    fig_SamplesAx2.set_title('Standard normal space')
+    fig_SamplesAx2.set_xlabel(r'$U_{1}$')
+    fig_SamplesAx2.set_ylabel(r'$U_{2}$')
+    fig_SamplesAx2.set_zlabel(r'$U_{3}$')
+    
+    plt.show()


### PR DESCRIPTION
Dear ERA-Team,

using the ERANataf-class within the realm of the CEBU algorithm, I noticed that the transformations from standard normal to physical space and vice versa solely calculate the Jacobian for the first data point. To my understanding, this it should calculate it for all of them such that the assessment of PDFs in both spaces can easily be conducted using the U2X or X2U functionalities of the ERANataf-class.
Further, I think that it might be of interest to return the absolute value of the determinant of the Jacobian as an additional output (or alternatively if the size of the whole Jacobians should be too large).
Many thanks in advance!

Best
Michael

PS.: unintentionally, the changes of the [pull request for the evidence calculation](https://github.com/ERA-Software/Overview/pull/1) are contained here as well!